### PR TITLE
Added alternative domains

### DIFF
--- a/src/shared/sources.json
+++ b/src/shared/sources.json
@@ -57,6 +57,7 @@
         "gogoanime": {
             "urls": [
                 "*://*.gogoanime.io/*episode*",
+                "*://*.gogoanime.se/*episode*",
                 "*://*.gogoanime.tv/*episode*"
             ],
             "title": {
@@ -88,6 +89,7 @@
         "kissanime": {
             "urls": [
                 "*://*.kissanime.ru/Anime/*",
+                "*://*.kissanime.ac/Anime/*",
                 "*://*.kissanime.to/Anime/*"
             ],
             "title": {


### PR DESCRIPTION
Kissanime and gogoanime alternatives as gogoanime links were changed already, and kissanime.ac just incase they will opt into that.